### PR TITLE
can: do not clear valid bit if Ipump is near limits

### DIFF
--- a/firmware/can.cpp
+++ b/firmware/can.cpp
@@ -204,11 +204,9 @@ void SendRusefiFormat(uint8_t ch)
 
     // Lambda is valid if:
     // 1. Nernst voltage is near target
-    // 2. Pump driver isn't slammed in to the stop
-    // 3. Lambda is >0.6 (sensor isn't specified below that)
+    // 2. Lambda is >0.6 (sensor isn't specified below that)
     bool lambdaValid =
             nernstDc > (NERNST_TARGET - 0.1f) && nernstDc < (NERNST_TARGET + 0.1f) &&
-            pumpDuty > 0.1f && pumpDuty < 0.9f &&
             lambda > 0.6f;
 
     if (configuration->afr[ch].RusEfiTx) {


### PR DESCRIPTION
We are measuring Ipump current and we are checking Vnernst. If Vnernst is within valid range that means that measured current is enough to keep target Vnernst and we can use this current to calculate valid AFR.

https://github.com/mck1117/wideband/issues/342